### PR TITLE
Make testing partners optional

### DIFF
--- a/process/2-research.md
+++ b/process/2-research.md
@@ -7,7 +7,7 @@ The working group consist of:
 * problem owners from each co-developing partner
 * product owners form each co-developing partner
 * technical team members from the co-developing partners
-* a representative from each testing partners
+* Optionally: a representative from each testing partners
 
 The working group does the following:
 


### PR DESCRIPTION
I suggest we make testing partners optional as this seems like a bridge too far for now.

I would like to make the change to make it possible to actively start enforcing this process.